### PR TITLE
Adjust position and modified box offset with fixed measurements.

### DIFF
--- a/css/positioning/styles.css
+++ b/css/positioning/styles.css
@@ -1,24 +1,31 @@
 
 
+
 #octopus {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  padding-top: 20px;
+  position: absolute;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: 75px;
+  padding-left: 50px;
+  padding-right: 50px;
+  z-index: 1;
+  outline: 1px solid red;
+
 }
 
 #hat {
-  position: absolute;
-  top: 28%;
-  left: 51%;
-  transform: translate(-50%, -50%);
+  position: relative;
+  top: 15px;
+  left: 30px;
+  z-index: 2;
+  outline: 1px solid red;
 }
 
 #glasses {
   position: absolute;
-  top: 48.75%;
-  left: 50.5%;
-  transform: translate(-50%, -50%);
+  top: 182px;
+  left: 100px;
+  z-index: 2;
 }
 


### PR DESCRIPTION
I realized that I was using relative measurements to control the box offsets of the images, so when I resized the page, the images would no longer be in line. I used fixed measurements and that fixed the problem.